### PR TITLE
fix Title issue with MediaWiki 1.44+

### DIFF
--- a/src/PluggableAuth.php
+++ b/src/PluggableAuth.php
@@ -11,7 +11,7 @@ use MediaWiki\User\UserGroupManager;
 use MWException as Exception;
 use RequestContext;
 use SpecialPage;
-use Title;
+use MediaWiki\Title\Title;
 
 /**
  * Class PluggableAuth


### PR DESCRIPTION
Fixes an issue which prevented the usage of the extension on MediaWiki 1.44 and above.